### PR TITLE
include stack trace with exceptions where possible

### DIFF
--- a/src/v8eval.cxx
+++ b/src/v8eval.cxx
@@ -161,7 +161,12 @@ std::string _V8::eval(const std::string& src) {
   } else {
     v8::Local<v8::Value> result;
     if (!script->Run(context).ToLocal(&result)) {
-      return to_std_string(try_catch.Exception());
+      v8::Local<v8::Value> stack;
+      if (!try_catch.StackTrace(context).ToLocal(&stack)) {
+        return to_std_string(try_catch.Exception());
+      } else {
+        return to_std_string(stack);
+      }
     } else {
       return to_std_string(json_stringify(context, result));
     }


### PR DESCRIPTION
I'm not really familiar with V8, but this worked for me and provided stack traces in the exception messages when the stack trace was included with the exception - `throw Error("message")` will include an exception, `throw "string error"` will not.

I tried doing the same thing with the call to `Compile()`, but that never seemed to include a stack trace (or wasn't accessible via this method).
