### PR TITLE
Add method to get v8 isolate heap memory usage

### DIFF
--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -46,6 +46,7 @@ type v8 struct {
 }
 
 type IsolateHeapInfo struct {
+	TotalPhysicalSize  uint64
 	TotalAvailableSize uint64
 	TotalHeapSize      uint64
 	UsedHeapSize       uint64
@@ -123,7 +124,10 @@ func (v *v8) Call(fun string, args interface{}, res interface{}) error {
 func (v *v8) GetHeapInformation() *IsolateHeapInfo {
 	infoMap := NewMapStringUint()
 	v.xV8.Get_heap_statistics(infoMap)
-	return &IsolateHeapInfo{TotalAvailableSize: infoMap.Get("total_available_size"), TotalHeapSize: infoMap.Get("total_heap_size"), UsedHeapSize: infoMap.Get("used_heap_size")}
+	return &IsolateHeapInfo{TotalAvailableSize: infoMap.Get("total_available_size"),
+		TotalHeapSize:     infoMap.Get("total_heap_size"),
+		UsedHeapSize:      infoMap.Get("used_heap_size"),
+		TotalPhysicalSize: infoMap.Get("total_physical_size")}
 }
 
 >>>>>>> attempt to expose isolate heap information

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"runtime"
 	"strings"
 )
 
@@ -66,26 +65,7 @@ func SetFlag(flagName string, value interface{}) {
 func NewV8() V8 {
 	v := new(v8)
 	v.xV8 = NewX_GoV8()
-	runtime.SetFinalizer(v, deleteV8)
 	return v
-}
-
-func deleteV8(v *v8) {
-	DeleteX_GoV8(v.xV8)
-	v.xV8 = nil
-}
-
-func (v *v8) Eval(src string, res interface{}) error {
-	return v.decode(v.xV8.Eval(src), res)
-}
-
-func (v *v8) Call(fun string, args interface{}, res interface{}) error {
-	as, err := json.Marshal(args)
-	if err != nil {
-		return err
-	}
-
-	return v.decode(v.xV8.Call(fun, string(as)), res)
 }
 
 func (v *v8) decode(str string, val interface{}) error {

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -100,14 +100,9 @@ func (v *v8) Call(fun string, args interface{}, res interface{}) error {
 }
 
 func (v *v8) GetHeapInformation() *IsolateHeapInfo {
-<<<<<<< 5a93c6fcbe4b065737be25fc01ebb4d56b1670a9
 	infoMap := NewMapStringUint()
 	v.xV8.Get_heap_statistics(infoMap)
 	return &IsolateHeapInfo{TotalAvailableSize: infoMap.Get("total_available_size"), TotalHeapSize: infoMap.Get("total_heap_size"), UsedHeapSize: infoMap.Get("used_heap_size")}
-=======
-	var infoMap map[string]int = v.xV8.Get_heap_statistics()
-	return &IsolateHeapInfo{TotalAvailableSize: infoMap["total_available_size"], TotalHeapSize: infoMap["total_heap_size"], UsedHeapSize: infoMap["used_heap_size"]}
->>>>>>> attempt to expose isolate heap information
 }
 
 func (v *v8) EnableDebugger(port int) error {

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -46,7 +46,6 @@ type v8 struct {
 }
 
 type IsolateHeapInfo struct {
-	TotalPhysicalSize  uint64
 	TotalAvailableSize uint64
 	TotalHeapSize      uint64
 	UsedHeapSize       uint64
@@ -103,10 +102,7 @@ func (v *v8) Call(fun string, args interface{}, res interface{}) error {
 func (v *v8) GetHeapInformation() *IsolateHeapInfo {
 	infoMap := NewMapStringUint()
 	v.xV8.Get_heap_statistics(infoMap)
-	return &IsolateHeapInfo{TotalAvailableSize: infoMap.Get("total_available_size"),
-		TotalHeapSize:     infoMap.Get("total_heap_size"),
-		UsedHeapSize:      infoMap.Get("used_heap_size"),
-		TotalPhysicalSize: infoMap.Get("total_physical_size")}
+	return &IsolateHeapInfo{TotalAvailableSize: infoMap.Get("total_available_size"), TotalHeapSize: infoMap.Get("total_heap_size"), UsedHeapSize: infoMap.Get("used_heap_size")}
 }
 
 func (v *v8) EnableDebugger(port int) error {

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -3,11 +3,7 @@ package v8eval
 import (
 	"encoding/json"
 	"errors"
-<<<<<<< ce1743e1ad74cdc39e3d425638f9ec94292038be
 	"runtime"
-=======
-	"fmt"
->>>>>>> first attempt at adding flag functionality
 	"strings"
 )
 

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -46,7 +46,6 @@ type v8 struct {
 }
 
 type IsolateHeapInfo struct {
-	TotalPhysicalSize  uint64
 	TotalAvailableSize uint64
 	TotalHeapSize      uint64
 	UsedHeapSize       uint64
@@ -124,10 +123,7 @@ func (v *v8) Call(fun string, args interface{}, res interface{}) error {
 func (v *v8) GetHeapInformation() *IsolateHeapInfo {
 	infoMap := NewMapStringUint()
 	v.xV8.Get_heap_statistics(infoMap)
-	return &IsolateHeapInfo{TotalAvailableSize: infoMap.Get("total_available_size"),
-		TotalHeapSize:     infoMap.Get("total_heap_size"),
-		UsedHeapSize:      infoMap.Get("used_heap_size"),
-		TotalPhysicalSize: infoMap.Get("total_physical_size")}
+	return &IsolateHeapInfo{TotalAvailableSize: infoMap.Get("total_available_size"), TotalHeapSize: infoMap.Get("total_heap_size"), UsedHeapSize: infoMap.Get("used_heap_size")}
 }
 
 >>>>>>> attempt to expose isolate heap information

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -3,7 +3,11 @@ package v8eval
 import (
 	"encoding/json"
 	"errors"
+<<<<<<< ce1743e1ad74cdc39e3d425638f9ec94292038be
 	"runtime"
+=======
+	"fmt"
+>>>>>>> first attempt at adding flag functionality
 	"strings"
 )
 

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -100,9 +100,14 @@ func (v *v8) Call(fun string, args interface{}, res interface{}) error {
 }
 
 func (v *v8) GetHeapInformation() *IsolateHeapInfo {
+<<<<<<< 5a93c6fcbe4b065737be25fc01ebb4d56b1670a9
 	infoMap := NewMapStringUint()
 	v.xV8.Get_heap_statistics(infoMap)
 	return &IsolateHeapInfo{TotalAvailableSize: infoMap.Get("total_available_size"), TotalHeapSize: infoMap.Get("total_heap_size"), UsedHeapSize: infoMap.Get("used_heap_size")}
+=======
+	var infoMap map[string]int = v.xV8.Get_heap_statistics()
+	return &IsolateHeapInfo{TotalAvailableSize: infoMap["total_available_size"], TotalHeapSize: infoMap["total_heap_size"], UsedHeapSize: infoMap["used_heap_size"]}
+>>>>>>> attempt to expose isolate heap information
 }
 
 func (v *v8) EnableDebugger(port int) error {

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -43,9 +43,9 @@ type v8 struct {
 }
 
 type IsolateHeapInfo struct {
-	TotalAvailableSize int
-	TotalHeapSize      int
-	UsedHeapSize       int
+	TotalAvailableSize uint64
+	TotalHeapSize      uint64
+	UsedHeapSize       uint64
 }
 
 // SetFlag sets a flag in the v8 engine and must be called before `Initialize()`
@@ -118,8 +118,9 @@ func (v *v8) Call(fun string, args interface{}, res interface{}) error {
 }
 
 func (v *v8) GetHeapInformation() *IsolateHeapInfo {
-	var infoMap map[string]int = v.xV8.Get_heap_statistics()
-	return &IsolateHeapInfo{TotalAvailableSize: infoMap["total_available_size"], TotalHeapSize: infoMap["total_heap_size"], UsedHeapSize: infoMap["used_heap_size"]}
+	infoMap := NewMapStringUint()
+	v.xV8.Get_heap_statistics(infoMap)
+	return &IsolateHeapInfo{TotalAvailableSize: infoMap.Get("total_available_size"), TotalHeapSize: infoMap.Get("total_heap_size"), UsedHeapSize: infoMap.Get("used_heap_size")}
 }
 
 >>>>>>> attempt to expose isolate heap information

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -3,6 +3,7 @@ package v8eval
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"runtime"
 	"strings"
 )
@@ -105,8 +106,6 @@ func (v *v8) decode(str string, val interface{}) error {
 	return nil
 }
 
-<<<<<<< 5f68c83265f4f85a003a64cf75a6ae44db62c169
-=======
 func (v *v8) Eval(src string, res interface{}) error {
 	return v.decode(v.xV8.Eval(src), res)
 }
@@ -126,7 +125,6 @@ func (v *v8) GetHeapInformation() *IsolateHeapInfo {
 	return &IsolateHeapInfo{TotalAvailableSize: infoMap.Get("total_available_size"), TotalHeapSize: infoMap.Get("total_heap_size"), UsedHeapSize: infoMap.Get("used_heap_size")}
 }
 
->>>>>>> attempt to expose isolate heap information
 func (v *v8) EnableDebugger(port int) error {
 	if !v.xV8.Enable_debugger(port) {
 		return errors.New("failed to start debug server")

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -31,6 +31,11 @@ type V8 interface {
 
 	// DisableDebugger stops the debug server, if running.
 	DisableDebugger()
+
+	// Tear down takes the V8 instance and tells the V8 engine to deallocate
+	// all of the resources allocated to it
+	// Do not try and use this V8 instance after calling teardown
+	TearDown()
 }
 
 type v8 struct {
@@ -91,4 +96,9 @@ func (v *v8) EnableDebugger(port int) error {
 
 func (v *v8) DisableDebugger() {
 	v.xV8.Disable_debugger()
+}
+
+func (v *v8) TearDown() {
+	DeleteX_GoV8(v.xV8)
+	v.xV8 = nil
 }

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -46,6 +46,7 @@ type v8 struct {
 }
 
 type IsolateHeapInfo struct {
+	TotalPhysicalSize  uint64
 	TotalAvailableSize uint64
 	TotalHeapSize      uint64
 	UsedHeapSize       uint64
@@ -102,7 +103,10 @@ func (v *v8) Call(fun string, args interface{}, res interface{}) error {
 func (v *v8) GetHeapInformation() *IsolateHeapInfo {
 	infoMap := NewMapStringUint()
 	v.xV8.Get_heap_statistics(infoMap)
-	return &IsolateHeapInfo{TotalAvailableSize: infoMap.Get("total_available_size"), TotalHeapSize: infoMap.Get("total_heap_size"), UsedHeapSize: infoMap.Get("used_heap_size")}
+	return &IsolateHeapInfo{TotalAvailableSize: infoMap.Get("total_available_size"),
+		TotalHeapSize:     infoMap.Get("total_heap_size"),
+		UsedHeapSize:      infoMap.Get("used_heap_size"),
+		TotalPhysicalSize: infoMap.Get("total_physical_size")}
 }
 
 func (v *v8) EnableDebugger(port int) error {

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -3,7 +3,6 @@ package v8eval
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 )
 
@@ -49,16 +48,6 @@ type IsolateHeapInfo struct {
 	TotalAvailableSize uint64
 	TotalHeapSize      uint64
 	UsedHeapSize       uint64
-}
-
-// SetFlag sets a flag in the v8 engine and must be called before `Initialize()`
-// i.e.: "expose_gc" or "max_old_space_size"
-func SetFlag(flagName string, value interface{}) {
-	flagString := fmt.Sprintf("--%s", flagName)
-	if value != nil {
-		flagString = fmt.Sprintf("%s=%+v", flagString, value)
-	}
-	SetV8Flag(flagString)
 }
 
 // NewV8 creates a new V8 instance.

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -24,6 +24,9 @@ type V8 interface {
 	// If some JavaScript exception happens in runtime, Call returns the exception as a Go error.
 	Call(fun string, args interface{}, res interface{}) error
 
+	// GetHeapInformation returns back information on the current heap information that v8 is using
+	GetHeapInformation() *IsolateHeapInfo
+
 	// EnableDebugger starts a debug server associated with the V8 instance.
 	// The server will listen on the given TCP/IP port.
 	// If failing to start the server, EnableDebugger returns the error.

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -46,6 +46,7 @@ func NewV8() V8 {
 }
 
 func deleteV8(v *v8) {
+
 	DeleteX_GoV8(v.xV8)
 	v.xV8 = nil
 }

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -42,6 +42,22 @@ type v8 struct {
 	xV8 X_GoV8
 }
 
+type IsolateHeapInfo struct {
+	TotalAvailableSize int
+	TotalHeapSize      int
+	UsedHeapSize       int
+}
+
+// SetFlag sets a flag in the v8 engine and must be called before `Initialize()`
+// i.e.: "expose_gc" or "max_old_space_size"
+func SetFlag(flagName string, value interface{}) {
+	flagString := fmt.Sprintf("--%s", flagName)
+	if value != nil {
+		flagString = fmt.Sprintf("%s=%+v", flagString, value)
+	}
+	SetV8Flag(flagString)
+}
+
 // NewV8 creates a new V8 instance.
 func NewV8() V8 {
 	v := new(v8)
@@ -86,6 +102,27 @@ func (v *v8) decode(str string, val interface{}) error {
 	return nil
 }
 
+<<<<<<< 5f68c83265f4f85a003a64cf75a6ae44db62c169
+=======
+func (v *v8) Eval(src string, res interface{}) error {
+	return v.decode(v.xV8.Eval(src), res)
+}
+
+func (v *v8) Call(fun string, args interface{}, res interface{}) error {
+	as, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+
+	return v.decode(v.xV8.Call(fun, string(as)), res)
+}
+
+func (v *v8) GetHeapInformation() *IsolateHeapInfo {
+	var infoMap map[string]int = v.xV8.Get_heap_statistics()
+	return &IsolateHeapInfo{TotalAvailableSize: infoMap["total_available_size"], TotalHeapSize: infoMap["total_heap_size"], UsedHeapSize: infoMap["used_heap_size"]}
+}
+
+>>>>>>> attempt to expose isolate heap information
 func (v *v8) EnableDebugger(port int) error {
 	if !v.xV8.Enable_debugger(port) {
 		return errors.New("failed to start debug server")

--- a/go/v8eval/v8.go
+++ b/go/v8eval/v8.go
@@ -46,7 +46,6 @@ func NewV8() V8 {
 }
 
 func deleteV8(v *v8) {
-
 	DeleteX_GoV8(v.xV8)
 	v.xV8 = nil
 }

--- a/go/v8eval/v8eval.i
+++ b/go/v8eval/v8eval.i
@@ -1,5 +1,6 @@
 %module v8eval
 %include "std_string.i"
+%include "std_map.i"
 
 %{
 #define SWIG_FILE_WITH_INIT
@@ -7,6 +8,10 @@
 %}
 
 %rename(SetFlags) set_flags;
+
+namespace std {
+    %template(MapStringUint) map<string,unsigned long long>;
+}
 
 %include "v8eval.h"
 %include "v8eval_go.h"

--- a/src/v8eval.cxx
+++ b/src/v8eval.cxx
@@ -221,6 +221,7 @@ void _V8::get_heap_statistics(std::map<std::string,unsigned long long> &heap_sta
 
   heap_stats["total_heap_size"] = v8_heap_stats.total_heap_size();
   heap_stats["total_available_size"] = v8_heap_stats.total_available_size();
+  heap_stats["total_physical_size"] = v8_heap_stats.total_physical_size();
   heap_stats["used_heap_size"] = v8_heap_stats.used_heap_size();
 }
 

--- a/src/v8eval.cxx
+++ b/src/v8eval.cxx
@@ -4,12 +4,12 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#include <map>
 
 #include "libplatform/libplatform.h"
 
 namespace v8eval {
 
-<<<<<<< 7930f14cfa241218f2185f19e2b2ed812f287fff
 using v8::HeapStatistics;
 
 static v8::Platform* platform = nullptr;
@@ -215,14 +215,18 @@ std::string _V8::call(const std::string& func, const std::string& args) {
 }
 
 
-void _V8::get_heap_statistics(std::map<std::string,unsigned long long> &heap_stats) {
+
+std::map<string,size_t> _V8::get_heap_statistics() {
   // V8 memory usage
+  std::map <string,size_t> heap_stats
   HeapStatistics v8_heap_stats;
   isolate_->GetHeapStatistics(&v8_heap_stats);
 
-  heap_stats["total_heap_size"] = v8_heap_stats.total_heap_size();
-  heap_stats["total_available_size"] = v8_heap_stats.total_available_size();
-  heap_stats["used_heap_size"] = v8_heap_stats.used_heap_size();
+  heap_stats["total_heap_size"] = v8_heap_stats.total_heap_size()
+  heap_stats["total_available_size"] = v8_heap_stats.total_available_size()
+  heap_stats["used_heap_size"] = v8_heap_stats.used_heap_size()
+
+  return heap_stats
 }
 
 bool _V8::enable_debugger(int port) {

--- a/src/v8eval.cxx
+++ b/src/v8eval.cxx
@@ -4,7 +4,6 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
-#include <map>
 
 #include "libplatform/libplatform.h"
 
@@ -215,17 +214,14 @@ std::string _V8::call(const std::string& func, const std::string& args) {
 }
 
 
-std::map<string,size_t> _V8::get_heap_statistics() {
+void _V8::get_heap_statistics(std::map<std::string,unsigned long long> &heap_stats) {
   // V8 memory usage
-  std::map <string,size_t> heap_stats
   HeapStatistics v8_heap_stats;
   isolate_->GetHeapStatistics(&v8_heap_stats);
 
-  heap_stats["total_heap_size"] = v8_heap_stats.total_heap_size()
-  heap_stats["total_available_size"] = v8_heap_stats.total_available_size()
-  heap_stats["used_heap_size"] = v8_heap_stats.used_heap_size()
-
-  return heap_stats
+  heap_stats["total_heap_size"] = v8_heap_stats.total_heap_size();
+  heap_stats["total_available_size"] = v8_heap_stats.total_available_size();
+  heap_stats["used_heap_size"] = v8_heap_stats.used_heap_size();
 }
 
 bool _V8::enable_debugger(int port) {

--- a/src/v8eval.cxx
+++ b/src/v8eval.cxx
@@ -4,7 +4,6 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
-#include <map>
 
 #include "libplatform/libplatform.h"
 
@@ -215,18 +214,14 @@ std::string _V8::call(const std::string& func, const std::string& args) {
 }
 
 
-
-std::map<string,size_t> _V8::get_heap_statistics() {
+void _V8::get_heap_statistics(std::map<std::string,unsigned long long> &heap_stats) {
   // V8 memory usage
-  std::map <string,size_t> heap_stats
   HeapStatistics v8_heap_stats;
   isolate_->GetHeapStatistics(&v8_heap_stats);
 
-  heap_stats["total_heap_size"] = v8_heap_stats.total_heap_size()
-  heap_stats["total_available_size"] = v8_heap_stats.total_available_size()
-  heap_stats["used_heap_size"] = v8_heap_stats.used_heap_size()
-
-  return heap_stats
+  heap_stats["total_heap_size"] = v8_heap_stats.total_heap_size();
+  heap_stats["total_available_size"] = v8_heap_stats.total_available_size();
+  heap_stats["used_heap_size"] = v8_heap_stats.used_heap_size();
 }
 
 bool _V8::enable_debugger(int port) {

--- a/src/v8eval.cxx
+++ b/src/v8eval.cxx
@@ -4,10 +4,13 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#include <map>
 
 #include "libplatform/libplatform.h"
 
 namespace v8eval {
+
+using v8::HeapStatistics;
 
 static v8::Platform* platform = nullptr;
 
@@ -209,6 +212,20 @@ std::string _V8::call(const std::string& func, const std::string& args) {
   } else {
     return to_std_string(json_stringify(context, result));
   }
+}
+
+
+std::map<string,size_t> _V8::get_heap_statistics() {
+  // V8 memory usage
+  std::map <string,size_t> heap_stats
+  HeapStatistics v8_heap_stats;
+  isolate_->GetHeapStatistics(&v8_heap_stats);
+
+  heap_stats["total_heap_size"] = v8_heap_stats.total_heap_size()
+  heap_stats["total_available_size"] = v8_heap_stats.total_available_size()
+  heap_stats["used_heap_size"] = v8_heap_stats.used_heap_size()
+
+  return heap_stats
 }
 
 bool _V8::enable_debugger(int port) {

--- a/src/v8eval.cxx
+++ b/src/v8eval.cxx
@@ -9,6 +9,7 @@
 
 namespace v8eval {
 
+<<<<<<< 7930f14cfa241218f2185f19e2b2ed812f287fff
 using v8::HeapStatistics;
 
 static v8::Platform* platform = nullptr;

--- a/src/v8eval.cxx
+++ b/src/v8eval.cxx
@@ -221,7 +221,6 @@ void _V8::get_heap_statistics(std::map<std::string,unsigned long long> &heap_sta
 
   heap_stats["total_heap_size"] = v8_heap_stats.total_heap_size();
   heap_stats["total_available_size"] = v8_heap_stats.total_available_size();
-  heap_stats["total_physical_size"] = v8_heap_stats.total_physical_size();
   heap_stats["used_heap_size"] = v8_heap_stats.used_heap_size();
 }
 

--- a/src/v8eval.h
+++ b/src/v8eval.h
@@ -2,6 +2,7 @@
 #define V8EVAL_H_
 
 #include <string>
+#include <map>
 
 #include "v8.h"
 #include "v8-debug.h"
@@ -57,6 +58,11 @@ class _V8 {
   /// and returns the result in JSON.
   /// If some JavaScript exception happens in runtime, the exception message is returned.
   std::string call(const std::string& func, const std::string& args);
+
+  /// |brief returns heap information for the current V8 isolate
+  /// |return returns a map where the keys are `total_heap_size`, `total_available_size`, and `used_heap_size`
+  /// This method returns a map with the isolate heap memory info. The values for each key is a number of bytes
+  void get_heap_statistics(std::map<std::string,unsigned long long> &heap_stats);
 
   /// \brief Start a debug server associated with the V8 instance
   /// \param port The TCP/IP port the debugger will listen, at localhost

--- a/src/v8eval.h
+++ b/src/v8eval.h
@@ -14,6 +14,7 @@ class DbgSrv;
 
 typedef void (*debugger_cb)(std::string&, void *opq);
 
+
 /// \brief Set the given V8 flags
 ///
 /// This method sets the given V8 flags.

--- a/src/v8eval.h
+++ b/src/v8eval.h
@@ -14,7 +14,6 @@ class DbgSrv;
 
 typedef void (*debugger_cb)(std::string&, void *opq);
 
-
 /// \brief Set the given V8 flags
 ///
 /// This method sets the given V8 flags.


### PR DESCRIPTION
This implements this suggestion: https://github.com/sony/v8eval/issues/20

I have found this code very useful for AWS Autoscaling and other box memory specific alterations
